### PR TITLE
GitHub actions for packing release files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: release
 
-on: [release]
+on:
+  release:
+    types: [created]
 
 jobs:
   build:
@@ -71,8 +73,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./${{ steps.dist.outputs.game-app-name }}
-        asset_name: ${{ steps.dist.outputs.game-app-name }}
+        asset_path: "./${{ steps.dist.outputs.game-app-name }}"
+        asset_name: "${{ steps.dist.outputs.game-app-name }}"
         asset_content_type: application/zip
 
     - name: Publish Release - testing, disabled

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     
-    strategy:
-      matrix:
-
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: release
 
 on:
   release:
-    types: [created]
+    types: [publish]
 
 jobs:
   build:
@@ -55,7 +55,7 @@ jobs:
         cd basepath/
         export DIST_FILE="${GAME_APP_NAME}-${GAME_APP_VERSION}-${GAME_APP_STAGE}.zip"
         echo "::set-output name=dist-file::$(echo ${DIST_FILE})"
-        zip -r "${DIST_FILE}" .
+        zip -r "../${DIST_FILE}" .
         echo "::set-output name=game-app-name::$(echo $GAME_APP_NAME)"
     - name: Create Draft Release
       id: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       run: |
         source config.sh
         cd basepath/
-        export DIST_FILE="${GAME_APP_NAME}-${GAME_APP_VERSION}-${GAME_APP_STAGE}.${{ github.action }}.zip"
+        export DIST_FILE="${GAME_APP_NAME}-${GAME_APP_VERSION}-${GAME_APP_STAGE}.${{ github.workflow }}.zip"
         echo "::set-output name=dist-file::$(echo ${DIST_FILE})"
         zip -r "../${DIST_FILE}" .
         echo "::set-output name=game-app-name::$(echo $GAME_APP_NAME)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: release
 
 on:
   release:
-    types: [publish]
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,16 +53,17 @@ jobs:
       run: |
         source config.sh
         cd basepath/
-        zip -r "${GAME_APP_NAME}-${GAME_APP_VERSION}-${GAME_APP_STAGE}" .
+        export DIST_FILE="${GAME_APP_NAME}-${GAME_APP_VERSION}-${GAME_APP_STAGE}.zip"
+        echo "::set-output name=dist-file::$(echo ${DIST_FILE})"
+        zip -r "${DIST_FILE}" .
         echo "::set-output name=game-app-name::$(echo $GAME_APP_NAME)"
-        echo "::set-output name=dist-file::$(echo test.zip)"
     - name: Create Draft Release
       id: create_release
       uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ steps.dist.outputs.game-app-name }}
+        tag_name: ${{ github.ref }}
         release_name: ${{ steps.dist.outputs.game-app-name }}
         draft: true
         prerelease: true
@@ -73,7 +74,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: "./${{ steps.dist.outputs.game-app-name }}"
+        asset_path: "./${{ steps.dist.outputs.dist-file }}"
         asset_name: "${{ steps.dist.outputs.game-app-name }}"
         asset_content_type: application/zip
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,8 @@ jobs:
       run: |
         ./sp-tools.sh default_config
         ./sp-tools.sh init
-        ./sp-tools.sh install_default_paks
+        # following fails because of shallow clone on checkout
+        #./sp-tools.sh install_default_paks 
         ./sp-tools.sh configure_cmake both
         ./sp-tools.sh build both
     - name: Dist package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       run: |
         source config.sh
         cd basepath/
-        export DIST_FILE="${GAME_APP_NAME}-${GAME_APP_VERSION}-${GAME_APP_STAGE}.${{ name }}.zip"
+        export DIST_FILE="${GAME_APP_NAME}-${GAME_APP_VERSION}-${GAME_APP_STAGE}.${{ github.action }}.zip"
         echo "::set-output name=dist-file::$(echo ${DIST_FILE})"
         zip -r "../${DIST_FILE}" .
         echo "::set-output name=game-app-name::$(echo $GAME_APP_NAME)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: release
+name: release-linux-x64
 
 on:
   release:
@@ -53,43 +53,18 @@ jobs:
       run: |
         source config.sh
         cd basepath/
-        export DIST_FILE="${GAME_APP_NAME}-${GAME_APP_VERSION}-${GAME_APP_STAGE}.zip"
+        export DIST_FILE="${GAME_APP_NAME}-${GAME_APP_VERSION}-${GAME_APP_STAGE}.${{ name }}.zip"
         echo "::set-output name=dist-file::$(echo ${DIST_FILE})"
         zip -r "../${DIST_FILE}" .
         echo "::set-output name=game-app-name::$(echo $GAME_APP_NAME)"
-    - name: Create Draft Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: ${{ steps.dist.outputs.game-app-name }}
-        draft: true
-        prerelease: true
 
-    - name: Upload Release
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Upload to Release
+      uses: svenstaro/upload-release-action@v2
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: "./${{ steps.dist.outputs.dist-file }}"
-        asset_name: "${{ steps.dist.outputs.game-app-name }}"
-        asset_content_type: application/zip
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: "./${{ steps.dist.outputs.dist-file }}"
+        asset_name: "${{ steps.dist.outputs.dist-file }}"
+        tag: ${{ github.ref }}
+        overwrite: true
+        body: "Automatically generated"
 
-    - name: Publish Release - testing, disabled
-      if: false
-      uses: eregon/publish-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        release_id: ${{ steps.create_release.outputs.id }}
-      
-    - name: Publish Release (alternative) - testing, disabled
-      if: false
-      uses: elgohr/Github-Release-Action@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-      with:
-        args: MyReleaseMessage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: |        
-        apt-get update
-        apt-get install -y \
+        sudo apt-get update && \
+        sudo apt-get install -y \
         cmake \
         cmake-curses-gui \
         gdb \
@@ -36,8 +36,8 @@ jobs:
         opencl-dev \
         rsync \
         tmux \
-        zip
-        apt-get clean
+        zip && \
+        sudo apt-get clean
     - name: Compile
       run: |
         ./sp-tools.sh default_config

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,8 @@ jobs:
     - name: Dist package
       id: dist
       run: |
-        cd basepath/
         source config.sh
+        cd basepath/
         zip -r "${GAME_APP_NAME}-${GAME_APP_VERSION}-${GAME_APP_STAGE}" .
         echo "::set-output name=game-app-name::$(echo $GAME_APP_NAME)"
         echo "::set-output name=dist-file::$(echo test.zip)"


### PR DESCRIPTION
I just got this to work. It compiles both server and client and creates a release package for Linux x64. We can add more actions for testing simple pushes and also for releasing to other architectures.

So far it's really simple, it's just building in an Ubuntu container and only packing the basepath folder. But we can fine tune it.

The trick is to manually create a new release on github and that will trigger the action. Go under the Actions tab to see previous runs.